### PR TITLE
Fix different suite storage ignored. Some additional cleanup.

### DIFF
--- a/Example/PDefaults.xcodeproj/project.pbxproj
+++ b/Example/PDefaults.xcodeproj/project.pbxproj
@@ -346,6 +346,7 @@
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -363,6 +364,7 @@
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		22E45E84630B4E0A30AE9E3FCC80DCAD /* Pods-PDefaults_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 43795D01EEB79E21086F15960B794CC9 /* Pods-PDefaults_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27EBDEE627777F4BE5FC8F7300A48251 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */; };
+		43A1DACE280CBD27000304EC /* OptionalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A1DACA280CBD27000304EC /* OptionalType.swift */; };
+		43A1DACF280CBD27000304EC /* Decodable+PDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A1DACB280CBD27000304EC /* Decodable+PDefaults.swift */; };
+		43A1DAD0280CBD27000304EC /* Encodable+PDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A1DACC280CBD27000304EC /* Encodable+PDefaults.swift */; };
+		43A1DAD1280CBD27000304EC /* UserDefaultsStorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A1DACD280CBD27000304EC /* UserDefaultsStorable.swift */; };
 		5C0E8E8B9CC72EAC9BAC99B0291619A2 /* PDefaults-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DBCEF27B4EC02EA42CE560C1B53AB11 /* PDefaults-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6CE9B88ACA8036DC6222463EF0323D22 /* Pods-PDefaults_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 33EAFDF46D62FB947C3010FD2229556B /* Pods-PDefaults_Tests-dummy.m */; };
 		7BF19B279B3CA21A8A07E6A8DCDA0651 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */; };
@@ -36,6 +40,10 @@
 		3A4F532B78E96AA04CB059337EE7E001 /* PDefaults-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PDefaults-prefix.pch"; sourceTree = "<group>"; };
 		3B4A91F2B753F9C1E5F7B1697355656A /* PDefaults-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PDefaults-dummy.m"; sourceTree = "<group>"; };
 		43795D01EEB79E21086F15960B794CC9 /* Pods-PDefaults_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PDefaults_Tests-umbrella.h"; sourceTree = "<group>"; };
+		43A1DACA280CBD27000304EC /* OptionalType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OptionalType.swift; path = PDefaults/Classes/OptionalType.swift; sourceTree = "<group>"; };
+		43A1DACB280CBD27000304EC /* Decodable+PDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Decodable+PDefaults.swift"; path = "PDefaults/Classes/Decodable+PDefaults.swift"; sourceTree = "<group>"; };
+		43A1DACC280CBD27000304EC /* Encodable+PDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Encodable+PDefaults.swift"; path = "PDefaults/Classes/Encodable+PDefaults.swift"; sourceTree = "<group>"; };
+		43A1DACD280CBD27000304EC /* UserDefaultsStorable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserDefaultsStorable.swift; path = PDefaults/Classes/UserDefaultsStorable.swift; sourceTree = "<group>"; };
 		4768320CC9972263BA53E99B2D9A3390 /* Pods-PDefaults_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-PDefaults_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		6879BE234574FD36987526823426135A /* PDefaults.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PDefaults.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F28CD9A6720CB5230DE89FDB4600F33 /* Pods-PDefaults_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-PDefaults_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
@@ -119,7 +127,11 @@
 		834DC1F904BA52A8CB1C56FFE5FCC11E /* PDefaults */ = {
 			isa = PBXGroup;
 			children = (
+				43A1DACB280CBD27000304EC /* Decodable+PDefaults.swift */,
+				43A1DACC280CBD27000304EC /* Encodable+PDefaults.swift */,
+				43A1DACA280CBD27000304EC /* OptionalType.swift */,
 				2E6783545F08C642F13639BD2B11E120 /* PDefaults.swift */,
+				43A1DACD280CBD27000304EC /* UserDefaultsStorable.swift */,
 				7FDEB0FA52BA62C85B90CA2FED69C396 /* Pod */,
 				DDD8CBCE782E18459789D92E3EA1BDAB /* Support Files */,
 			);
@@ -295,8 +307,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43A1DACE280CBD27000304EC /* OptionalType.swift in Sources */,
 				92D88A128576CBE84A11A54AD245E9F0 /* PDefaults-dummy.m in Sources */,
+				43A1DACF280CBD27000304EC /* Decodable+PDefaults.swift in Sources */,
 				CA759C1317B9944AA04F18136B770A46 /* PDefaults.swift in Sources */,
+				43A1DAD1280CBD27000304EC /* UserDefaultsStorable.swift in Sources */,
+				43A1DAD0280CBD27000304EC /* Encodable+PDefaults.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-PDefaults_Tests.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-PDefaults_Tests.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "903FBDC63D2C86BA969CB8FE70294204"
+               BuildableName = "Pods_PDefaults_Tests.framework"
+               BlueprintName = "Pods-PDefaults_Tests"
+               ReferencedContainer = "container:Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "903FBDC63D2C86BA969CB8FE70294204"
+            BuildableName = "Pods_PDefaults_Tests.framework"
+            BlueprintName = "Pods-PDefaults_Tests"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Tests/TestPublisher.swift
+++ b/Example/Tests/TestPublisher.swift
@@ -4,11 +4,11 @@ import PDefaults
 class TestPublisher: XCTestCase {
 
     let key = "mickey"
-    let storage = UserDefaults.standard
+    let suite = UserDefaults.standard
 
     override func setUp() {
         super.setUp()
-        storage.removeObject(forKey: key)
+        suite.removeObject(forKey: key)
     }
 
     override func tearDown() {
@@ -16,7 +16,7 @@ class TestPublisher: XCTestCase {
     }
 
     func testClosureCalledOnSink() {
-        let pdefaults = PDefaults(wrappedValue: 1, key, storage: storage)
+        let pdefaults = PDefaults(wrappedValue: 1, key, suite: suite)
         var called = false
         let cancellable = pdefaults.projectedValue.sink { _ in
             called = true
@@ -27,7 +27,7 @@ class TestPublisher: XCTestCase {
 
     func testNotPresentingValueWhilePublishing() {
         let initValue = 1
-        let pdefaults = PDefaults(wrappedValue: initValue, key, storage: storage)
+        let pdefaults = PDefaults(wrappedValue: initValue, key, suite: suite)
         let cancellable = pdefaults.projectedValue.sink { _ in
             XCTAssert(pdefaults.wrappedValue == initValue, "While sinking, the directly accessed value should be the previous one")
         }
@@ -37,7 +37,7 @@ class TestPublisher: XCTestCase {
 
     func testPresentingValueWhilePublishing() {
         let newValue = 2
-        let pdefaults = PDefaults(wrappedValue: 1, key, storage: storage, behavior: .didSet)
+        let pdefaults = PDefaults(wrappedValue: 1, key, suite: suite, behavior: .didSet)
         var isFirstReceive = true
         let cancellable = pdefaults.projectedValue.sink { _ in
             if !isFirstReceive {
@@ -51,7 +51,7 @@ class TestPublisher: XCTestCase {
 
     func testSinkRightValue() {
         var lastValue = 1
-        let pdefaults = PDefaults(wrappedValue: lastValue, key, storage: storage)
+        let pdefaults = PDefaults(wrappedValue: lastValue, key, suite: suite)
         let cancellable = pdefaults.projectedValue.sink { value in
             XCTAssert(value == lastValue, "While sinking, the directly accessed value should be the previous one")
         }

--- a/Example/Tests/TestStorage.swift
+++ b/Example/Tests/TestStorage.swift
@@ -4,11 +4,11 @@ import PDefaults
 class TestStorage: XCTestCase {
 
     let key = "mickey"
-    let storage = UserDefaults.standard
+    let suite = UserDefaults.standard
 
     override func setUp() {
         super.setUp()
-        storage.removeObject(forKey: key)
+        suite.removeObject(forKey: key)
     }
     
     override func tearDown() {
@@ -16,23 +16,23 @@ class TestStorage: XCTestCase {
     }
     
     func testNoStorageWhenNotNeeded() {
-        let pDefaults = PDefaults(wrappedValue: Optional.some(1), key, storage: storage)
-        XCTAssert(storage.object(forKey: key) == nil, "Storage should not contain a value for key \"\(key)\"")
+        let pDefaults = PDefaults(wrappedValue: Optional.some(1), key, suite: suite)
+        XCTAssert(suite.object(forKey: key) == nil, "Storage should not contain a value for key \"\(key)\"")
         _ = pDefaults.wrappedValue
-        XCTAssert(storage.object(forKey: key) == nil, "Storage should not contain a value for key \"\(key)\"")
+        XCTAssert(suite.object(forKey: key) == nil, "Storage should not contain a value for key \"\(key)\"")
         _ = pDefaults.projectedValue
-        XCTAssert(storage.object(forKey: key) == nil, "Storage should not contain a value for key \"\(key)\"")
+        XCTAssert(suite.object(forKey: key) == nil, "Storage should not contain a value for key \"\(key)\"")
         pDefaults.wrappedValue = nil
-        XCTAssert(storage.object(forKey: key) == nil, "Storage should not contain a value for key \"\(key)\"")
+        XCTAssert(suite.object(forKey: key) == nil, "Storage should not contain a value for key \"\(key)\"")
         pDefaults.wrappedValue = 1
         pDefaults.wrappedValue = nil
-        XCTAssert(storage.object(forKey: key) == nil, "Storage should not contain a value for key \"\(key)\"")
+        XCTAssert(suite.object(forKey: key) == nil, "Storage should not contain a value for key \"\(key)\"")
     }
 
     func testStorageValueInt() {
-        let pDefaults = PDefaults(wrappedValue: 1, key, storage: storage)
+        let pDefaults = PDefaults(wrappedValue: 1, key, suite: suite)
         pDefaults.wrappedValue = 2
-        XCTAssert(storage.object(forKey: key) as? Int == 2, "Storage contain the value set to wrappedValue")
+        XCTAssert(suite.object(forKey: key) as? Int == 2, "Storage contains the value set to wrappedValue")
         XCTAssert(pDefaults.wrappedValue == 2, "Wrapped value should expose the set value")
     }
 
@@ -42,24 +42,32 @@ class TestStorage: XCTestCase {
 
     func testCodableStorageDefaultValueNoImpact() {
         // Storage: nil
-        let pDefaults = PDefaults<CodableStruct?>(wrappedValue: nil, key, storage: storage)
+        let pDefaults = PDefaults<CodableStruct?>(wrappedValue: nil, key, suite: suite)
         let codable = CodableStruct(string: "youpi")
         pDefaults.wrappedValue = codable
         // Storage: codable
         let otherCodable = CodableStruct(string: "hello")
-        let pDefaults2 = PDefaults<CodableStruct>(wrappedValue: otherCodable, key, storage: storage)
+        let pDefaults2 = PDefaults<CodableStruct>(wrappedValue: otherCodable, key, suite: suite)
         XCTAssert(pDefaults2.wrappedValue == codable, "Wrapped value should be equal to the value stored using the same key")
     }
 
     func testCodableStorageNilDefaultValueNoImpact() {
         // Storage: nil
-        var pDefaults = PDefaults<CodableStruct?>(wrappedValue: nil, key, storage: storage)
+        var pDefaults = PDefaults<CodableStruct?>(wrappedValue: nil, key, suite: suite)
         let codable = CodableStruct(string: "youpi")
         let otherCodable = CodableStruct(string: "hello")
-        let pDefaults2 = PDefaults<CodableStruct>(wrappedValue: codable, key, storage: storage)
+        let pDefaults2 = PDefaults<CodableStruct>(wrappedValue: codable, key, suite: suite)
         pDefaults2.wrappedValue = otherCodable
         // Storage: otherCodable
-        pDefaults = PDefaults<CodableStruct?>(wrappedValue: nil, key, storage: storage)
+        pDefaults = PDefaults<CodableStruct?>(wrappedValue: nil, key, suite: suite)
         XCTAssert(pDefaults.wrappedValue == otherCodable, "Wrapped value should be equal to the value stored using the same key")
+    }
+
+    func testDistinctSuiteStorage() {
+        let otherSuite = UserDefaults(suiteName: "dingo")!
+        let pDefaults = PDefaults(wrappedValue: 1, key, suite: otherSuite)
+        pDefaults.wrappedValue = 2
+        XCTAssert(otherSuite.object(forKey: key) as? Int == 2, "Distinct suite contains the value set to wrappedValue")
+        XCTAssert(pDefaults.wrappedValue == 2, "Wrapped value should expose the set value")
     }
 }

--- a/PDefaults/Classes/Decodable+PDefaults.swift
+++ b/PDefaults/Classes/Decodable+PDefaults.swift
@@ -1,0 +1,22 @@
+//
+//  Decodable+PDefaults.swift
+//  PDefaults
+//
+//  Created by Pierre Mardon on 17/04/2022.
+//
+
+import Foundation
+
+extension Decodable {
+    /// `Decodable` mapping for reading from storage
+    static func decodableReadMapper(_ object: Any?) -> Self? {
+        guard let data = object as? Data else { return nil }
+        do {
+            return try JSONDecoder().decode(self, from: data)
+        } catch {
+            print("Couldn't decode \(String(describing: object))", error)
+            // Very opinionated choice to almost ignore thrown errors
+            return nil
+        }
+    }
+}

--- a/PDefaults/Classes/Encodable+PDefaults.swift
+++ b/PDefaults/Classes/Encodable+PDefaults.swift
@@ -1,0 +1,23 @@
+//
+//  Encodable+PDefaults.swift
+//  PDefaults
+//
+//  Created by Pierre Mardon on 17/04/2022.
+//
+
+import Foundation
+
+extension Encodable {
+    /// `Encodable` mapping for storage
+    static func codableWriteMapper(_ value: Self) -> Any? {
+        if let optValue = self as? OptionalType, optValue.isNil() {
+            return nil
+        }
+        do {
+            return try JSONEncoder().encode(value)
+        } catch {
+            print("Couldn't encode \(value)", error)
+            return nil
+        }
+    }
+}

--- a/PDefaults/Classes/OptionalType.swift
+++ b/PDefaults/Classes/OptionalType.swift
@@ -1,0 +1,28 @@
+//
+//  OptionalType.swift
+//  PDefaults
+//
+//  Created by Pierre Mardon on 17/04/2022.
+//
+
+import Foundation
+
+/// Protocol for Optional types only, adding a `isNil()` func to them
+protocol OptionalType {
+    /// Returns nil if the value or the recursively wrapped value is `Optional.none` aka `nil`
+    func isNil() -> Bool
+}
+
+/// Making Optional types implement our recursive `nil` check protocol
+extension Optional: OptionalType {
+    func isNil() -> Bool {
+        if self == nil {
+            return true
+        }
+        let unwrapped = unsafelyUnwrapped
+        if unwrapped is OptionalType {
+            return (unwrapped as! OptionalType).isNil()
+        }
+        return false
+    }
+}

--- a/PDefaults/Classes/UserDefaultsStorable.swift
+++ b/PDefaults/Classes/UserDefaultsStorable.swift
@@ -1,0 +1,34 @@
+//
+//  UserDefaultsStorable.swift
+//  PDefaults
+//
+//  Created by Pierre Mardon on 17/04/2022.
+//
+
+import Foundation
+
+/// Flag protocol: any type implementing this protocol can be stored natively using UserDefaults
+public protocol UserDefaultsStorable {}
+
+/**
+ Declare proper flag protocol conformance for all types natively compatible with UserDefaults storage
+ */
+
+extension String : UserDefaultsStorable {}
+extension Int: UserDefaultsStorable {}
+extension Double: UserDefaultsStorable {}
+extension Float: UserDefaultsStorable {}
+extension Date: UserDefaultsStorable {}
+extension Data: UserDefaultsStorable {}
+extension Array: UserDefaultsStorable where Element: UserDefaultsStorable {}
+extension Dictionary: UserDefaultsStorable where Key == String, Value: UserDefaultsStorable {}
+extension Optional: UserDefaultsStorable where Wrapped: UserDefaultsStorable {}
+
+extension UserDefaultsStorable {
+
+    /// `UserDefaultsStorable` mapping for storage
+    static func writeMapper(_ value: Self) -> Any? { value }
+
+    /// `UserDefaultsStorable` mapping for reading from storage
+    static func readMapper(_ object: Any?) -> Self? { object as? Self }
+}


### PR DESCRIPTION
- migrate to XCode 13.3.1
- rename `storage` to `suite`
- add and enhance code documentation
- split source code into several files, closes #1
- replace hard coded use of `UserDefaults.standard` by proper variable, closes #2
- remove unused enum `SubjectHolder` (`Optional` was already used instead)
- use function references instead of inline blocks for write and read mappers values