### PR TITLE
Fix initial `nil` value for default non-nil value

### DIFF
--- a/Sources/PDefaults/Decodable+PDefaults.swift
+++ b/Sources/PDefaults/Decodable+PDefaults.swift
@@ -7,16 +7,16 @@
 
 import Foundation
 
+enum DecodableError: Error {
+    case cannotCastStoredObjectAsData(Any?)
+}
+
 extension Decodable {
     /// `Decodable` mapping for reading from storage
-    static func decodableReadMapper(_ object: Any?) -> Self? {
-        guard let data = object as? Data else { return nil }
-        do {
-            return try JSONDecoder().decode(self, from: data)
-        } catch {
-            print("Couldn't decode \(String(describing: object))", error)
-            // Opinionated choice to almost ignore thrown errors
-            return nil
+    static func decodableReadMapper(_ object: Any) throws -> Self {
+        guard let data = object as? Data else {
+            throw DecodableError.cannotCastStoredObjectAsData(object)
         }
+        return try JSONDecoder().decode(self, from: data)
     }
 }

--- a/Sources/PDefaults/Encodable+PDefaults.swift
+++ b/Sources/PDefaults/Encodable+PDefaults.swift
@@ -7,18 +7,16 @@
 
 import Foundation
 
+enum EncodableError: Error {
+    case cannotEncodeNil
+}
+
 extension Encodable {
     /// `Encodable` mapping for storage
-    static func codableWriteMapper(_ value: Self) -> Any? {
-        if let optValue = self as? OptionalType, optValue.isNil() {
-            return nil
+    static func codableWriteMapper(_ value: Self) throws -> Any {
+        if let optValue = value as? OptionalType, optValue.isNil() {
+            throw EncodableError.cannotEncodeNil
         }
-        do {
-            return try JSONEncoder().encode(value)
-        } catch {
-            print("Couldn't encode \(value)", error)
-            // Opinionated choice to almost ignore thrown errors
-            return nil
-        }
+        return try JSONEncoder().encode(value)
     }
 }

--- a/Sources/PDefaults/UserDefaultsStorable.swift
+++ b/Sources/PDefaults/UserDefaultsStorable.swift
@@ -24,11 +24,26 @@ extension Array: UserDefaultsStorable where Element: UserDefaultsStorable {}
 extension Dictionary: UserDefaultsStorable where Key == String, Value: UserDefaultsStorable {}
 extension Optional: UserDefaultsStorable where Wrapped: UserDefaultsStorable {}
 
+enum UserDefaultsStorableError: Error {
+    case cannotCastToType(Any.Type)
+    case cannotStoreNil
+}
+
 extension UserDefaultsStorable {
 
     /// `UserDefaultsStorable` mapping for storage
-    static func writeMapper(_ value: Self) -> Any? { value }
+    static func writeMapper(_ value: Self) throws -> Any {
+        if let optValue = value as? OptionalType, optValue.isNil() {
+            throw UserDefaultsStorableError.cannotStoreNil
+        }
+        return value
+    }
 
     /// `UserDefaultsStorable` mapping for reading from storage
-    static func readMapper(_ object: Any?) -> Self? { object as? Self }
+    static func readMapper(_ object: Any) throws -> Self {
+        if let value = object as? Self {
+            return value
+        }
+        throw UserDefaultsStorableError.cannotCastToType(Self.self)
+    }
 }

--- a/Tests/PDefaultsTests/TestPublisher.swift
+++ b/Tests/PDefaultsTests/TestPublisher.swift
@@ -59,4 +59,12 @@ class TestPublisher: XCTestCase {
         pdefaults.wrappedValue = lastValue
         cancellable.cancel()
     }
+
+    func testOptionalSinkNotNil() {
+        let pdefaults = PDefaults<String?>(wrappedValue: "coucou", key, suite: suite)
+        let cancellable = pdefaults.projectedValue.sink { value in
+            XCTAssert(value != nil, "While sinking, we don't expect any nil value initially")
+        }
+        cancellable.cancel()
+    }
 }


### PR DESCRIPTION
Closes #10

`nil` values were unexpectedly published and stored as a value in `PDefaults` instances with optional value type even when the default value was not nil.

- manage generic value properly to avoid optional leading to double optional. Instead, use error throwing to signal a failure
- implement issue reproduction test